### PR TITLE
Support for mongodb:// URL scheme

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -12,17 +12,17 @@ var safetyNet = require('./util').safetyNet,
 
 // [mongo://][username:password@]hostname[:port][/databasename]
 
-var UrlMatcher = /^(?:mongo:\/\/)?(?:([^:]+):([^@]+)@)?(.+?)(?::([0-9]+))?(?:\/(.*))?$/
+var UrlMatcher = /^(?:mongo(db)?:\/\/)?(?:([^:]+):([^@]+)@)?(.+?)(?::([0-9]+))?(?:\/(.*))?$/
 
 function parseUrl(url) {
     var match = UrlMatcher.exec(url)
-    if (!match || !match[3]) throw new Error("Invalid connection string: "+arg)
+    if (!match || !match[4]) throw new Error("Invalid connection string: "+arg)
     url = {}
-    if (match[1]) url.user = decodeURIComponent(match[1])
-    if (match[2]) url.password = decodeURIComponent(match[2])
-    url.host = match[3] || 'localhost'
-    url.port = (+match[4]) || 27017
-    if (match[5]) url.database = decodeURIComponent(match[5])
+    if (match[2]) url.user = decodeURIComponent(match[2])
+    if (match[3]) url.password = decodeURIComponent(match[3])
+    url.host = match[4] || 'localhost'
+    url.port = (+match[5]) || 27017
+    if (match[6]) url.database = decodeURIComponent(match[6])
     return url
 }
 


### PR DESCRIPTION
Hi Marcello,

I noticed that the connection URL one gets from mongohq/heroku use the URL scheme mongodb:// instead of mongo:// and hence added support for that. 

Cheers

Matthias
