### PR TITLE
Error if save has no callback parameter.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -16,7 +16,11 @@ exports.safetyNet = function(callback,body) {
         if (error) {
             callback && callback(error)
         } else {
-            body.apply(this, Array.prototype.slice.call(arguments,1))
+            try {
+                body.apply(this, Array.prototype.slice.call(arguments,1))
+            } catch (ex) {
+                callback && callback(ex)
+            }
         }
     }
 }


### PR DESCRIPTION
I generally don't give a callback for collection.save(), but recently this started throwing an error. This seems to fix it.
