### PR TITLE
semi-workaround for https://github.com/marcello3d/node-mongolian/issues/6

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -27,7 +27,7 @@ MongolianDB.prototype._addgetter = function (name) {
         });
         return true;
     } else {
-        this.server.log.warn('"' + name + '" is already in the class and can\'t be used as a shortcut to the collection.');
+        //this.server.log.debug('"' + name + '" is already in the class and can\'t be used as a shortcut to the collection.');
         return false;
     }
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -6,19 +6,40 @@ var safetyNet = require('./util').safetyNet,
     MongolianCollection = require('./collection'),
     MongolianGridFS = require('./gridfs')
 
-var MongolianDB = module.exports = function(server, name) {
+var MongolianDB = module.exports = function(server, name, collections) {
     this.server = server
     this.name = name
     this._collections = {}
     this._gridfss = {}
+    for(var i in collections) {
+        this.collection(collections[i]); //precache the collection
+    }
+}
+
+/**
+ * add a read-only getter for the specific collection
+ */
+MongolianDB.prototype._addgetter = function (name) {
+    //so we wouldn't accidently delete a function or something
+    if(!this[name] && this._collections[name]){
+        this.__defineGetter__(name, function() {
+            return this._collections[name];
+        });
+        return true;
+    } else {
+        this.server.log.warn('"' + name + '" is already in the class and can\'t be used as a shortcut to the collection.');
+        return false;
+    }
 }
 
 /**
  * Get a collection
  */
 MongolianDB.prototype.collection = function(name) {
-    return this._collections[name] ||
-          (this._collections[name] = new MongolianCollection(this, name))
+    var c = this._collections[name] ||
+          (this._collections[name] = new MongolianCollection(this, name));
+    this._addgetter(name)
+	return c;
 }
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -164,9 +164,9 @@ Mongolian.prototype.dbNames = function(callback) {
 /**
  * Get a database
  */
-Mongolian.prototype.db = function(name) {
+Mongolian.prototype.db = function(name, collections) {
     return this._dbs[name] ||
-          (this._dbs[name] = new MongolianDB(this, name))
+          (this._dbs[name] = new MongolianDB(this, name, collections))
 }
 
 Mongolian.prototype.toString = function() {


### PR DESCRIPTION
There are 2 ways to activate it :
1. Pass an array of collection names to the db constructor.
   ex : `db = server.db('test', ['col1', 'col2'])`
2. Call `db.collections('col1')` first then col1 will be
   added to the db object.

I tested it and it seems to work, this is my very first attempt
    with node/mongodb.
