### PR TITLE
Fix for issue #28 - connecting to mongos was not working

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -52,7 +52,7 @@ var Mongolian = module.exports = function(serversOrOptions) {
             delete self.sendCommand
             server.sendCommand(command,callback)
         }
-        self.db('').runCommand({ ismaster:1 }, function(error, result) {
+        self.db('admin').runCommand({ ismaster:1 }, function(error, result) {
             if (error) {
                 scanErrors.push(error)
             } else {


### PR DESCRIPTION
When connecting through mongos, the database 'admin' should be explicitly specified. Before the fix, mongos was returning the following error: 'assertion s/config.h:119'.
After changing empty db name to 'admin', the command works well and correctly identifies the current connection as connection to master.
