### PR TITLE
fixed node-mongolian dying silently

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -248,8 +248,9 @@ function MongolianServer(mongolian, url) {
 //                    mongolian.log.debug("<<<---",require('util').inspect(reply,undefined,undefined,true).slice(0,5000))
                     delete self._callbacks[reply.responseTo]
                     self._callbackCount--
-                    reply.parseBody(message, bsonSerializer)
-                    cb(null,reply)
+                    reply.parseBody(message, bsonSerializer, null, function() {
+                      cb(null,reply)
+                    })
                 }
             }
         })


### PR DESCRIPTION
I fixed a bug that was introduced by a change in mongodb-native. reply.parseBody now takes in a callback, which I updated in the pull request.
