### PR TITLE
Server connection won't close

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -223,6 +223,7 @@ function MongolianServer(mongolian, url) {
             maxBsonSize:4 * 1024 * 1024 * 4 * 3
         })
         var connected = false
+        callback(null, connection)
         connection.on('error', function(error) {
             mongolian.log.error(self+": "+require('util').inspect(error))
             if (!connected) callback(error)


### PR DESCRIPTION
It seems to be an issue with MongolianServer._connection not having a cached value until one of the connections callbacks is called, it fixes the issue of you call the callback right away.

it doesn't break any of the existing tests, but I couldn't think of a clever way to test this without digging into internals.
