### PR TITLE
Added logging for user-callback errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -237,7 +237,7 @@ function MongolianServer(mongolian, url) {
             connected = true
             callback(null, connection)
         })
-        connection.on("message", function(message) {
+        connection.on('message', function(message) {
             var reply = new mongo.MongoReply
             reply.parseHeader(message, bsonSerializer)
             if (reply.messageLength != message.length) {
@@ -249,10 +249,17 @@ function MongolianServer(mongolian, url) {
                     delete self._callbacks[reply.responseTo]
                     self._callbackCount--
                     reply.parseBody(message, bsonSerializer, null, function() {
-                      cb(null,reply)
+                        try {
+                            cb(null,reply)
+                        } catch(err) {
+                            connection.emit('callbackError', err)
+                        }
                     })
                 }
             }
+        })
+        connection.on('callbackError', function(error) {
+            mongolian.log.error(self+": CallbackError: "+error.stack)
         })
         connection.start()
     })


### PR DESCRIPTION
I was having issues tracking my errors raised from within my callback to .insert().

There are two ways to catch this... You can listen to connection.on('parseError', ...), or you can just try-catch. I think the try-catch is a better approach.

I feel that there is more to do here... maybe the user of mongolian-deadbeef should be able to register a callback for callbackErrors for a server/db/connection/cursor.
