### PR TITLE
remove duplicate file name deletion. filename is not a unique identifier.

### DIFF
--- a/lib/gridfile.js
+++ b/lib/gridfile.js
@@ -25,23 +25,12 @@ var MongolianGridFile = module.exports = function(gridfs, document) {
  * Saves all the metadata associated with this file
  */
 MongolianGridFile.prototype.save = function(callback) {
+    
     var self = this
-
     var waiter = new Waiter
+    
     if (!self._id) {
         self._id = new buffalo.ObjectId
-        var findCallback = waiter()
-        // Remove existing file
-        self.gridfs.findOne({
-            filename:self.filename,
-            id:{ $ne:self._id }
-        },safetyNet(callback,function(file) {
-            if (file) {
-                file.remove(findCallback)
-            } else {
-                findCallback()
-            }
-        }))
     }
 
     var document = {
@@ -53,11 +42,12 @@ MongolianGridFile.prototype.save = function(callback) {
         contentType: self.contentType,
         uploadDate: self.uploadDate
     }
+    
     // Optional fields
     if (self.aliases) document.aliases = self.aliases
     if (self.metadata) document.metadata = self.metadata
+    
     self.gridfs.files.save(document, waiter())
-
     waiter.waitForAll(callback)
 }
 


### PR DESCRIPTION
After reading the MongoDB documentation, it does not look like a file's name is supposed to be a unique identifier in GridFS. Looking over the Mongolian code, the `MongolianGridFile#save` method performs a `findOne` query, using the `filename` and `id` properties. If it locates a file with the same name, it deletes it. How to save files with the same name, then? I believe this is a mistake in the code. I also do not recognized the used `id` property - is that supposed to be `_id`? The existing GridFS file record does not have an `id` record, so that'll never match anyways, as far as I can tell.

I have removed this check-and-delete logic and the code appears to function as I would expect, now. I am able to insert multiple files with the same name, and they're giving their own record in GridFS.

This does break the unit tests, but after looking over the unit tests it looks like they were written from the perspective of a file's name being unique, which I think invalidates the unit tests as a whole for GridFS, and so I did not bother updating them.

Can we review the reasons why you consider `filename` to be unique, @marcello3d?
