### PR TITLE
in repliace env, set hosts as Array to new Mongolian

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -97,21 +97,43 @@ var Mongolian = module.exports = function(serversOrOptions) {
     }
 
     // Browse the constructor arguments
-    for (var i=0; i<arguments.length; i++) {
-        var arg = arguments[i]
-        if (typeof arg === 'string') {
-            var url = parseUrl(arg)
-            addServer(url)
-            if (url.database) inlineDatabase = url
-        } else if (typeof arg === 'object') {
-            if (typeof arg.log !== 'undefined') {
-                for (var logLevel in this.log) {
-                    this.log[logLevel] = (arg.log && arg.log[logLevel]) || function() {}
-                }
-            }
-            if (arg.host) addServer(arg)
+    // 1. dburi
+    // 2. dburi1[, dburiX]+
+    // 3. "dburi1,dburi2,..."
+    // 4. dburi, opt
+    // 5. dburi1[, dburiX]+, opt
+    // 6. "dburi1,dburi2,...", opt
+    // 7. opt
+    var hosts = [], opt = {};
+    for(var i = 0; i < arguments.length; i++){
+      var arg = arguments[i];
+      if(typeof arg === 'string'){
+        if(arg.indexOf(',') > -1){
+          hosts = hosts.concat(arg.split(/\s*,\s*/).map(function(uri){ return parseUrl(uri); }))
+        }else{
+          hosts.push(parseUrl(arg))
+        }
+      }else if(arg instanceof Array){
+        hosts = hosts.concat(arg.map(function(uri){ return parseUrl(uri); }))
+      }else if(typeof arg === 'object'){
+        for(var attr in arg){
+          if(arg.hasOwnProperty(attr)){
+            opt[attr] = arg[attr]
+          }
+        }
+      }
+    }
+    for(var i = 0; i < hosts.length; i++){
+        addServer(hosts[i])
+        if (hosts[i].database) inlineDatabase = hosts[i]
+    }
+    if(typeof opt.log !== 'undefined'){
+        for (var logLevel in this.log) {
+            this.log[logLevel] = (opt.log && opt.log[logLevel]) || function() {}
         }
     }
+    if(opt.host) addServer(opt)
+  
     if (!this._servers.length) {
         addServer(parseUrl('localhost'))
     }

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,44 @@
+/* Mongolian DeadBeef by Marcello Bastea-Forte - zlib license */
+
+var Mongolian = require('../mongolian')
+
+var server, db, collection
+var hosts = [
+  'mongodb://localhost',
+  'mongodb://localhost:27018',
+  'localhost:27019'
+]
+
+module.exports = {
+  "create connection in replica set in arguments": function(test) {
+    server = new Mongolian(hosts[0], hosts[1], hosts[2], { log:false });
+    test.equals(server._servers.length, 3)
+    test.ok(server._serverNames['localhost:27017'])
+    test.ok(server._serverNames['localhost:27018'])
+    test.ok(server._serverNames['localhost:27019'])
+    
+    db = server.db('mongolian_test')
+    collection = db.collection('testindex')
+    db.dropDatabase(function(error){
+      test.ifError(error)
+
+      server.close()
+      test.done()
+    })
+  },
+  "create connection in replica set with Array": function(test) {
+    server = new Mongolian(hosts, { log:false });
+    test.equals(server._servers.length, 3)
+    test.ok(server._serverNames['localhost:27017'])
+    test.ok(server._serverNames['localhost:27018'])
+    test.ok(server._serverNames['localhost:27019'])
+    
+    db = server.db('mongolian_test')
+    collection = db.collection('testindex')
+    db.dropDatabase(function(error){
+      test.ifError(error)
+      server.close()
+      test.done()
+    })
+  }
+};


### PR DESCRIPTION
We have replica server info in Array

```
var hosts = ["localhost:27017", "localhost:27018", "localhost:27019"];
```

In master branch, we must set each arguments to create mongolian client to replica set, such that

```
var server = new Mongolian("localhost:27017", "localhost:27018", "localhost:27019");
```

But the number of servers are not specified in code, but are specified in config.
So in this patch, we can create mongolian client such that,

```
var hosts = ["localhost:27017", "localhost:27018", "localhost:27019"];
var server = new Mongolian(hosts);
```
