### PR TITLE
Bind logger methods to the logger

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -106,7 +106,7 @@ var Mongolian = module.exports = function(serversOrOptions) {
         } else if (typeof arg === 'object') {
             if (typeof arg.log !== 'undefined') {
                 for (var logLevel in this.log) {
-                    this.log[logLevel] = (arg.log && arg.log[logLevel]) || function() {}
+                    this.log[logLevel] = (arg.log && arg.log[logLevel]) && arg.log[logLevel].bind(arg.log) || function() {}
                 }
             }
             if (arg.host) addServer(arg)

--- a/lib/server.js
+++ b/lib/server.js
@@ -106,7 +106,7 @@ var Mongolian = module.exports = function(serversOrOptions) {
         } else if (typeof arg === 'object') {
             if (typeof arg.log !== 'undefined') {
                 for (var logLevel in this.log) {
-                    this.log[logLevel] = (arg.log && arg.log[logLevel]) && arg.log[logLevel].bind(arg.log) || function() {}
+                    this.log[logLevel] = (arg.log && arg.log[logLevel] && arg.log[logLevel].bind(arg.log)) || function() {}
                 }
             }
             if (arg.host) addServer(arg)


### PR DESCRIPTION
When specifying a custom logger, the logger methods are not bound to the logger.
In particular it prevents using [logule](https://github.com/clux/logule) as a custom logger.
This pull request fixes it.
