### PR TITLE
Add isCapped(callback) method to collection.js

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -294,6 +294,21 @@ MongolianCollection.prototype.distinct = function(key, query, callback) {
     }))
 }
 
+MongolianCollection.prototype.isCapped = function(callback) {
+    collName = this.db.name + "." + this.name;
+    this.db.collection("system.namespaces").findOne({name:collName}, function(err, result) {
+        if (typeof callback !== 'function') return;
+        if (err) {
+            callback(err)
+        }
+        if (!result || !result.options) {
+            callback("Could not find this Collection.")
+        } else {
+            callback(null, result.options.capped, result.options.size)
+        }
+    })
+}
+
 MongolianCollection.prototype.toString = function() {
     return this.db + "." + this.name
 }


### PR DESCRIPTION
I made a little bit alteration for your library, which will support `isCapped()` in that [official documents](http://docs.mongodb.org/manual/reference/method/db.collection.isCapped/#db.collection.isCapped) if u merge this request.
This change maybe match your 2nd TODO `Various utility methods`. So my question is solved, then looking forward your mergence.
